### PR TITLE
Script for automatic setup of required Security Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,33 @@ Apache Storm deploy on EC2 made easy.
 
 ## Dependencies
 
-* boto3
+- boto3
+- pyyaml
 
-* pyyaml
+## AWS requirements
+
+1. An AWS account :-)
+2. An AWS Access Key
+3. An AMI for launching EC2 instances including Java 7 and Python 2.6.6
+4. A default VPC, with a default subnet and a default Security Group
+5. (A bunch of Security Groups for the Storm cluster: you can easily setup them
+		using `setup-security-groups.py`)
+
+## Configuration
+
+Create a `config.yaml` configuration file starting from `config.example.yaml`.
+
+**If you need to setup required Security Groups:** prepare your configuration file
+entering all required settings (keep example data for the Storm cluster security groups). 
+Then, run:
+
+	python setup-security-groups.py
+
+and paste generated lines into `config.yaml`.
+
+## Usage
+
+	python teacup-storm.py start
+	python teacup-storm.py stop
+
+

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,6 +3,8 @@ region_name: "eu-central-1"
 aws_access_key_id: "EXAMPLEKEYID"
 aws_secret_access_key: "exAmplE-Secr3t-K3y"
 key_pair: "key_name"
+default_vpc: "vpc-cd421fa4"
+default_vpc_security_group: "sg-fa4ca692"
 security_groups_zk: ["sg-f87e2690", "sg-fa4ca692", "sg-de1a46b6"]
 security_groups_ni: ["sg-fa4ca692", "sg-dee8cfb6", "sg-de1a46b6"]
 security_groups_sv: ["sg-fa4ca692", "sg-02e8cf6a", "sg-de1a46b6"]

--- a/configuration.py
+++ b/configuration.py
@@ -1,8 +1,5 @@
 import yaml
 
-''' Global configuration object. '''
-global config
-
 class Configuration:
     def __init__(self):
         conf = self.parse_configuration_file('config.yaml')
@@ -15,6 +12,8 @@ class Configuration:
         self.get_required_parameter(conf, 'security_groups_ui')
         self.get_required_parameter(conf, 'security_groups_ni')
         self.get_required_parameter(conf, 'security_groups_sv')
+        self.get_required_parameter(conf, 'default_vpc')
+        self.get_required_parameter(conf, 'default_vpc_security_group')
         self.get_parameter(conf, 'zk_instances', 1)
         
     def parse_configuration_file(self, config_file):

--- a/setup-security-groups.py
+++ b/setup-security-groups.py
@@ -11,6 +11,10 @@ from configuration import Configuration
 # Global configuration object
 config=None
 
+# Needed security groups
+group_names = [ 'teacup-storm-ssh', 'teacup-storm-ui', 'teacup-storm-zk', 'teacup-storm-nimbus', 'teacup-storm-sv' ]
+security_groups = { name:None for name in group_names}
+
         
 ''' Creates a session using user-provided custom credentials. '''
 def create_session():
@@ -22,16 +26,55 @@ def create_session():
     )
     return session
 
-def create_security_groups(session):
-    # TODO
+def create_security_group(vpc, name, description=''):
+    try:
+        return vpc.create_security_group(GroupName=name, Description=description)    
+    except boto3.exceptions.botocore.client.ClientError as e:
+        print("[ERROR] Failed to create security group '{}' ({})"
+                .format(_name, e.response['Error']['Code']))
+        exit(2)
+
+def create_zookeeper_sg(vpc):
+    sg = create_security_group(vpc, 'teacup-storm-zk', 'Opens ports for ZK')
+    # TODO configure group
+
+def print_configuration():
     pass
+    # TODO
+
+def get_group_by_name (vpc, name):
+    sg = None
+
+    filters=[{"Name":"group-name", "Values": ["{}".format(name)]}]
+    for i in vpc.security_groups.filter(filters):
+        sg = i
+
+    return sg
 
 def main():
     global config
+
     config = Configuration()
     session = create_session()
+    vpc = session.resource('ec2').Vpc(config.default_vpc)
 
-    create_security_groups(session)
+    # Searches for already existing groups (if any)
+    for name in security_groups.keys():
+        security_groups[name] = get_group_by_name(vpc, name)
+        if security_groups[name] != None:
+            print("[WARNING] Security group '{}' already exists (please, rename "
+                   "it if you manually created it for a different purpose and "
+                   "re-run this tool)".format(name))
+
+    # Creates needed groups
+    if security_groups['teacup-storm-zk'] == None:
+        security_groups['teacup-storm-zk'] = create_zookeeper_sg(vpc)
+
+
+    # TODO other groups
+
+    # Prints configuration to paste into YAML file
+    print_configuration()
     
 if __name__ == "__main__":
     main()

--- a/setup-security-groups.py
+++ b/setup-security-groups.py
@@ -1,0 +1,37 @@
+'''
+Creates required security groups on EC2 and prints lines to be pasted 
+into YAML configuration.
+'''
+
+import sys
+import boto3
+import yaml
+from configuration import Configuration
+
+# Global configuration object
+config=None
+
+        
+''' Creates a session using user-provided custom credentials. '''
+def create_session():
+    global config
+    session = boto3.session.Session(
+        aws_access_key_id = config.aws_access_key_id,
+        aws_secret_access_key = config.aws_secret_access_key,
+        region_name = config.region_name
+    )
+    return session
+
+def create_security_groups(session):
+    # TODO
+    pass
+
+def main():
+    global config
+    config = Configuration()
+    session = create_session()
+
+    create_security_groups(session)
+    
+if __name__ == "__main__":
+    main()

--- a/setup-security-groups.py
+++ b/setup-security-groups.py
@@ -36,17 +36,51 @@ def create_security_group(vpc, name, description=''):
 
 def create_zookeeper_sg(vpc):
     sg = create_security_group(vpc, 'teacup-storm-zk', 'Opens ports for ZK')
-    # TODO configure group
+    sg.authorize_ingress(IpProtocol="tcp",CidrIp="0.0.0.0/0",FromPort=2181,ToPort=2181)
+    sg.authorize_ingress(IpProtocol="udp",CidrIp="0.0.0.0/0",FromPort=2181,ToPort=2181)
+
+def create_nimbus_sg(vpc):
+    sg = create_security_group(vpc, 'teacup-storm-nimbus', 'Opens ports for Nimbus')
+    sg.authorize_ingress(IpProtocol="tcp",CidrIp="0.0.0.0/0",FromPort=6627,ToPort=6627)
+    sg.authorize_ingress(IpProtocol="udp",CidrIp="0.0.0.0/0",FromPort=6627,ToPort=6627)
+
+def create_supervisor_sg(vpc):
+    sg = create_security_group(vpc, 'teacup-storm-sv', 'Opens ports for Supervisor')
+    sg.authorize_ingress(IpProtocol="tcp",CidrIp="0.0.0.0/0",FromPort=6700,ToPort=6703)
+    sg.authorize_ingress(IpProtocol="udp",CidrIp="0.0.0.0/0",FromPort=6700,ToPort=6703)
+
+def create_ui_sg(vpc):
+    sg = create_security_group(vpc, 'teacup-storm-ui', 'Opens ports for UI')
+    sg.authorize_ingress(IpProtocol="tcp",CidrIp="0.0.0.0/0",FromPort=8080,ToPort=8080)
+
+def create_ssh_sg(vpc):
+    sg = create_security_group(vpc, 'teacup-storm-ssh', 'Opens ports for SSH')
+    sg.authorize_ingress(IpProtocol="tcp",CidrIp="0.0.0.0/0",FromPort=22,ToPort=22)
 
 def print_configuration():
-    pass
-    # TODO
+    """ Prints lines to be pasted into config.yaml. """
+    print("Add following lines to config.yaml")
+    print(30*'-')
+
+    _ssh = security_groups['teacup-storm-ssh'].id
+    _default = config.default_vpc_security_group
+    _ui = security_groups['teacup-storm-ui'].id
+    _sv = security_groups['teacup-storm-sv'].id
+    _nimbus = security_groups['teacup-storm-nimbus'].id
+    _zk = security_groups['teacup-storm-zk'].id
+
+    print('security_groups_zk: ["{}", "{}", "{}"]'.format(_default, _ssh, _zk))
+    print('security_groups_ni: ["{}", "{}", "{}"]'.format(_default, _ssh, _nimbus))
+    print('security_groups_sv: ["{}", "{}", "{}"]'.format(_default, _ssh, _sv))
+    print('security_groups_ui: ["{}", "{}", "{}"]'.format(_default, _ssh, _ui))
+    print(30*'-')
 
 def get_group_by_name (vpc, name):
+    """ Returns a SecurityGroup given its name. """
     sg = None
 
-    filters=[{"Name":"group-name", "Values": ["{}".format(name)]}]
-    for i in vpc.security_groups.filter(filters):
+    _filters=[{"Name":"group-name", "Values": ["{}".format(name)]}]
+    for i in vpc.security_groups.filter(Filters=_filters):
         sg = i
 
     return sg
@@ -69,9 +103,14 @@ def main():
     # Creates needed groups
     if security_groups['teacup-storm-zk'] == None:
         security_groups['teacup-storm-zk'] = create_zookeeper_sg(vpc)
-
-
-    # TODO other groups
+    if security_groups['teacup-storm-nimbus'] == None:
+        security_groups['teacup-storm-nimbus'] = create_nimbus_sg(vpc)
+    if security_groups['teacup-storm-sv'] == None:
+        security_groups['teacup-storm-sv'] = create_supervisor_sg(vpc)
+    if security_groups['teacup-storm-ssh'] == None:
+        security_groups['teacup-storm-ssh'] = create_ssh_sg(vpc)
+    if security_groups['teacup-storm-ui'] == None:
+        security_groups['teacup-storm-ui'] = create_ui_sg(vpc)
 
     # Prints configuration to paste into YAML file
     print_configuration()


### PR DESCRIPTION
`setup-security-groups.py` allows you to automatically create and configure all required Security Groups for Storm cluster. You just need a default VPC and the associated default Security Group (which should already exist in your AWS account).

The `README.md` has been updated to provide basic instructions about configuring and using `setup-security-groups.py` and `teacup-storm.py`.