### PR TITLE
Adds options to pick different instance type for components

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ Here is a list of supported configuration options:
 - `supervisor_ami_id`: (optional) ID of specific AMI to use for Supervisor instance(s)
 - `ui_ami_id`: (optional) ID of specific AMI to use for UI instance(s)
 - `zookeeper_ami_id`: (optional) ID of specific AMI to use for ZooKeeper instance(s)
+- `default_instance_type`: (optional) instance type to use for launched instances
+- `nimbus_instance_type`: (optional) instance type to use for Nimbus instance(s)
+- `supervisor_instance_type`: (optional) instance type to use for Supervisor instance(s)
+- `ui_instance_type`: (optional) instance type to use for UI instance(s)
+- `zookeeper_instance_type`: (optional) instance type to use for ZooKeeper instance(s)
 
 ## Usage
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -16,7 +16,7 @@ nimbus_ami_id: "ami-abcd0123"
 supervisor_ami_id: "ami-bcde1234"
 ui_ami_id: "ami-abce2345"
 zookeeper_ami_id: "ami-edcb3456"
-instance_type: "t2.small"
+default_instance_type: "t2.micro"
 subnet_id: "subnet-b81522d1"
 volume_size: 8
 ...

--- a/configuration.py
+++ b/configuration.py
@@ -23,7 +23,11 @@ class Configuration:
         self.get_parameter(conf, 'zk_instances', 1)
         self.get_parameter(conf, 'supervisors', 1)
         self.get_parameter(conf, 'slots', 4)
-        self.get_parameter(conf, 'instance_type', 't2.micro')
+        self.get_parameter(conf, 'default_instance_type', 't2.micro')
+        self.get_parameter(conf, 'nimbus_instance_type', self.default_instance_type)
+        self.get_parameter(conf, 'ui_instance_type', self.default_instance_type)
+        self.get_parameter(conf, 'supervisor_instance_type', self.default_instance_type)
+        self.get_parameter(conf, 'zookeeper_instance_type', self.default_instance_type)
         self.get_parameter(conf, 'volume_size', 8)
         
     def parse_configuration_file(self, config_file):

--- a/teacup-storm.py
+++ b/teacup-storm.py
@@ -33,7 +33,7 @@ def get_ami_id(name):
     return ami_id
 
 ''' Starts a single ec2 instance. '''
-def start_ec2_instance(session, userdata, securitygroups, name, count=1):
+def start_ec2_instance(session, userdata, securitygroups, name, type, count=1):
     ami_id = get_ami_id(name)            
     ec2 = session.resource('ec2')
     instances = ec2.Subnet(config.subnet_id).create_instances(
@@ -41,7 +41,7 @@ def start_ec2_instance(session, userdata, securitygroups, name, count=1):
         MinCount=count,
         MaxCount=count,
         KeyName=config.key_pair,
-        InstanceType=config.instance_type,
+        InstanceType=type,
         UserData=userdata,
         SecurityGroupIds=securitygroups,
         BlockDeviceMappings=[
@@ -137,7 +137,7 @@ def start_zk_instance(session):
     global config
     userdata = get_zk_userdata()
     return start_ec2_instance(session, userdata, config.security_groups_zk,
-        "zookeeper")
+        "zookeeper", config.zookeeper_instance_type)
 
 def start_nimbus_instance(session, zk_instances):
     global config
@@ -151,7 +151,7 @@ def start_nimbus_instance(session, zk_instances):
     userdata = userdata.replace("_STORM_SERVICE_", "nimbus")
     userdata = userdata.replace("_SUPERVISOR_PORTS_", "")
     return start_ec2_instance(session, userdata, config.security_groups_ni,
-        "nimbus")
+        "nimbus", config.nimbus_instance_type)
 
 def compute_supervisor_ports(slots=4):
     supervisor_ports = "echo 'supervisor.slots.ports:' >> ./storm.yaml\n"
@@ -182,7 +182,7 @@ def start_supervisor_instance(session, zk_instances, nimbus_instances):
     userdata = userdata.replace("_SUPERVISOR_PORTS_", supervisor_ports)
     userdata = userdata.replace("_STORM_SERVICE_", "supervisor")
     return start_ec2_instance(session, userdata, config.security_groups_sv,
-        "supervisor", config.supervisors)
+        "supervisor", config.supervisor_instance_type, config.supervisors)
 
 def start_ui_instance(session, zk_instances, nimbus_instances):
     global config
@@ -203,7 +203,7 @@ def start_ui_instance(session, zk_instances, nimbus_instances):
     userdata = userdata.replace("_STORM_SERVICE_", "ui")
     userdata = userdata.replace("_SUPERVISOR_PORTS_", "")
     return start_ec2_instance(session, userdata, config.security_groups_ui,
-        "ui")
+        "ui", config.ui_instance_type)
 
 def start_storm_cluster(session):
     zk_instances = start_zk_instance(session)


### PR DESCRIPTION
`instance_type` configuration entry has been removed, and new
per-component options has been added. In this way, the user can deploy
different components on different EC2 instances.